### PR TITLE
🔐 feat: Implement Custom SSL Certificates API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This SDK provides clients for:
 -   📊 **Metrics**: Query detailed performance and visitor analytics.
 -   🚀 **Tasks**: Run bulk operations across all your sites.
 -   🌐 **Edge Cache**: Control caching and DDoS protection.
+-   🔐 **Custom SSL Certificates**: Stage, activate, and manage your own SSL certificates.
 -   ⚙️ **Servers**: Get information on available datacenters and PHP versions.
 -   👤 **Client**: Manage account-wide settings like webhooks.
 -   ✉️ **Email**: Check the email sending blocklist.

--- a/atomic_sdk/api/custom_certificates.py
+++ b/atomic_sdk/api/custom_certificates.py
@@ -335,7 +335,7 @@ class CustomCertificatesClient(ResourceClient):
             activate_result["certificate_id"] = certificate_id
             return activate_result
             
-        except Exception as e:
+        except Exception:
             # Rollback: Attempt to delete the staged certificate
             try:
                 self.delete(certificate_id=certificate_id, site_id=site_id, domain=domain)

--- a/atomic_sdk/api/custom_certificates.py
+++ b/atomic_sdk/api/custom_certificates.py
@@ -303,8 +303,9 @@ class CustomCertificatesClient(ResourceClient):
 
         Args matches stage().
         
-        This method includes rollback logic: if activation fails, it attempts to
-        delete the staged certificate to prevent orphans.
+        This method includes rollback logic: if activation fails (either via exception
+        or via an `activated: false` response), it attempts to delete the staged
+        certificate to prevent orphans.
         """
         # Stage the certificate first
         stage_result = self.stage(
@@ -322,6 +323,14 @@ class CustomCertificatesClient(ResourceClient):
         if not certificate_id:
             raise RuntimeError("Failed to get certificate ID from staging response")
 
+        def _rollback() -> None:
+            """Attempt to delete the staged certificate."""
+            try:
+                self.delete(certificate_id=certificate_id, site_id=site_id, domain=domain)
+            except Exception:
+                # Swallow delete error so caller sees the original activation error
+                pass
+
         try:
             # Activate the staged certificate
             activate_result = self.activate(
@@ -331,16 +340,19 @@ class CustomCertificatesClient(ResourceClient):
                 domains=domains,
             )
 
+            # Check if activation was successful via response field
+            if not activate_result.get("activated", True):
+                _rollback()
+                raise RuntimeError(
+                    f"Activation returned false for certificate {certificate_id}. "
+                    "Staged certificate has been rolled back."
+                )
+
             # Include the certificate ID in the response for convenience
             activate_result["certificate_id"] = certificate_id
             return activate_result
             
         except Exception:
             # Rollback: Attempt to delete the staged certificate
-            try:
-                self.delete(certificate_id=certificate_id, site_id=site_id, domain=domain)
-            except Exception:
-                # Fallback: if delete fails, we can't do much more, but we swallow the delete error
-                # so the user sees the original activation error.
-                pass
+            _rollback()
             raise

--- a/atomic_sdk/api/custom_certificates.py
+++ b/atomic_sdk/api/custom_certificates.py
@@ -160,20 +160,13 @@ class CustomCertificatesClient(ResourceClient):
         This fetches the list of certificates and returns the first one marked as active.
         Returns None if no active certificate is found.
         """
-        # Fetch a small batch, active certs should be prioritized or exist in the list
-        # We can filter by status='active' if the API correctly supports filtering by status.
-        # Assuming status='active' works as per previous implementation plan.
-        try:
-            result = self.list(site_id=site_id, domain=domain, status='active', limit=1)
-            certificates = result.get('certificates', [])
-            if certificates:
-                 # Double check is_active flag just in case
-                 cert = certificates[0]
-                 if cert.get('is_active'):
-                     return cert
-        except Exception:
-            pass
-            
+        result = self.list(site_id=site_id, domain=domain, status='active', limit=1)
+        certificates = result.get('certificates', [])
+        if certificates:
+            # Double check is_active flag just in case
+            cert = certificates[0]
+            if cert.get('is_active'):
+                return cert
         return None
 
     def list(
@@ -350,4 +343,4 @@ class CustomCertificatesClient(ResourceClient):
                 # Fallback: if delete fails, we can't do much more, but we swallow the delete error
                 # so the user sees the original activation error.
                 pass
-            raise e
+            raise

--- a/atomic_sdk/api/custom_certificates.py
+++ b/atomic_sdk/api/custom_certificates.py
@@ -342,7 +342,6 @@ class CustomCertificatesClient(ResourceClient):
 
             # Check if activation was successful via response field
             if not activate_result.get("activated", True):
-                _rollback()
                 raise RuntimeError(
                     f"Activation returned false for certificate {certificate_id}. "
                     "Staged certificate has been rolled back."

--- a/atomic_sdk/api/custom_certificates.py
+++ b/atomic_sdk/api/custom_certificates.py
@@ -1,0 +1,353 @@
+"""
+Client for managing custom SSL certificates for WP Cloud sites.
+
+This module provides functionality to stage, activate, deactivate, delete,
+and retrieve custom SSL certificates via the WP Cloud Atomic API.
+"""
+
+from typing import Optional, List, Dict, Any, Union
+
+from .base import ResourceClient
+
+
+class CustomCertificatesClient(ResourceClient):
+    """
+    A client for managing custom SSL certificates on WP Cloud sites.
+
+    Custom certificates allow you to use your own SSL/TLS certificates
+    instead of the automatically provisioned Let's Encrypt certificates.
+
+    The typical workflow is:
+    1. Stage a certificate using `stage()` - validates and stores the certificate
+    2. Activate the staged certificate using `activate()` - makes it live
+    3. Optionally deactivate with `deactivate()` to switch back to auto-provisioned
+    4. Delete old/unused certificates with `delete()`
+    """
+
+    def _get_identifier(
+        self, site_id: Optional[int] = None, domain: Optional[str] = None
+    ) -> Union[int, str]:
+        """Internal helper to get the site identifier for endpoints in this group."""
+        if domain:
+            return domain
+        if site_id:
+            return site_id
+        raise ValueError("You must provide either a 'site_id' or a 'domain'.")
+
+    def _prepare_domains_data(self, data: Dict[str, Any], domains: Optional[List[str]]) -> None:
+        """Helper to correctly serialize domains array for PHP/WP Cloud API."""
+        if domains:
+            # PHP-based APIs typically expect 'domains[]' for array data in form-urlencoded POST requests.
+            # Requests library will serialize {'domains[]': ['a', 'b']} as 'domains[]=a&domains[]=b'.
+            data["domains[]"] = domains
+
+    def stage(
+        self,
+        certificate: str,
+        private_key: str,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        domains: Optional[List[str]] = None,
+        csr: Optional[str] = None,
+        trusted_certificates: Optional[str] = None,
+        client_certificate: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Stage a custom SSL certificate for later activation.
+
+        Args:
+            certificate: PEM-encoded SSL certificate, or certificate chain.
+            private_key: PEM-encoded private key.
+            site_id: The Atomic site ID.
+            domain: The domain name of the site.
+            domains: Optional list of domains to validate the certificate for.
+            csr: Optional PEM-encoded CSR.
+            trusted_certificates: Optional PEM-encoded trusted CA certificates.
+            client_certificate: Optional PEM-encoded client certificate.
+
+        Returns:
+            Dictionary with staging result.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/stage"
+
+        data: Dict[str, Any] = {
+            "certificate": certificate,
+            "private_key": private_key,
+        }
+
+        self._prepare_domains_data(data, domains)
+        
+        if csr:
+            data["csr"] = csr
+        if trusted_certificates:
+            data["trusted_certificates"] = trusted_certificates
+        if client_certificate:
+            data["client_certificate"] = client_certificate
+
+        return self._post(endpoint, data=data)
+
+    def activate(
+        self,
+        certificate_id: int,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        domains: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Activate a previously staged custom SSL certificate.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/{certificate_id}/activate"
+
+        data: Dict[str, Any] = {}
+        self._prepare_domains_data(data, domains)
+
+        return self._post(endpoint, data=data if data else None)
+
+    def deactivate(
+        self,
+        certificate_id: int,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Deactivate a custom SSL certificate.
+
+        Args:
+            certificate_id: The ID of the certificate to deactivate.
+            site_id: The Atomic site ID.
+            domain: The domain name of the site.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/{certificate_id}/deactivate"
+        return self._post(endpoint)
+
+    def delete(
+        self,
+        certificate_id: int,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Delete a custom SSL certificate.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/{certificate_id}/delete"
+        return self._post(endpoint)
+
+    def get(
+        self,
+        certificate_id: int,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get details for a specific custom SSL certificate.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/{certificate_id}"
+        return self._get(endpoint)
+    
+    def get_active(
+        self,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Helper to retrieve the currently active certificate for a site.
+        
+        This fetches the list of certificates and returns the first one marked as active.
+        Returns None if no active certificate is found.
+        """
+        # Fetch a small batch, active certs should be prioritized or exist in the list
+        # We can filter by status='active' if the API correctly supports filtering by status.
+        # Assuming status='active' works as per previous implementation plan.
+        try:
+            result = self.list(site_id=site_id, domain=domain, status='active', limit=1)
+            certificates = result.get('certificates', [])
+            if certificates:
+                 # Double check is_active flag just in case
+                 cert = certificates[0]
+                 if cert.get('is_active'):
+                     return cert
+        except Exception:
+            pass
+            
+        return None
+
+    def list(
+        self,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+        expiring_within_days: Optional[int] = None,
+        order_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        List custom SSL certificates for a site.
+
+        Args:
+            site_id: The Atomic site ID.
+            domain: The domain name of the site.
+            status: Filter by status ('active', 'staged', 'all').
+            limit: Max number of results (default 100).
+            offset: Pagination offset (default 0).
+            expiring_within_days: Filter certs expiring within N days.
+            order_by: Sort order ('expiration', 'created').
+
+        Returns:
+            Dictionary containing list of 'certificates' and 'pagination' info.
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/list"
+
+        params: Dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+        }
+        if status:
+            params["status"] = status
+        if expiring_within_days is not None:
+            params["expiring_within_days"] = expiring_within_days
+        if order_by:
+            params["order_by"] = order_by
+
+        return self._get(endpoint, params=params)
+
+    def update(
+        self,
+        certificate_id: int,
+        certificate: Optional[str] = None,
+        private_key: Optional[str] = None,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        domains: Optional[List[str]] = None,
+        csr: Optional[str] = None,
+        trusted_certificates: Optional[str] = None,
+        client_certificate: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Update/Renew an existing custom certificate.
+
+        Args:
+            certificate_id: ID of the certificate to update.
+            certificate: Optional new PEM-encoded SSL certificate.
+            private_key: Optional new PEM-encoded private key.
+            domains: Optional new list of domains.
+            ... other optional fields ...
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/{certificate_id}/update"
+
+        data: Dict[str, Any] = {}
+        
+        if certificate:
+            data["certificate"] = certificate
+        if private_key:
+            data["private_key"] = private_key
+            
+        self._prepare_domains_data(data, domains)
+        
+        if csr:
+            data["csr"] = csr
+        if trusted_certificates:
+            data["trusted_certificates"] = trusted_certificates
+        if client_certificate:
+            data["client_certificate"] = client_certificate
+
+        return self._post(endpoint, data=data)
+
+    def validate(
+        self,
+        certificate: str,
+        private_key: str,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        domains: Optional[List[str]] = None,
+        csr: Optional[str] = None,
+        trusted_certificates: Optional[str] = None,
+        client_certificate: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Validate a certificate and private key without saving.
+
+        Args matches stage().
+        """
+        identifier = self._get_identifier(site_id, domain)
+        endpoint = f"/custom-certificates/{identifier}/validate"
+
+        data: Dict[str, Any] = {
+            "certificate": certificate,
+            "private_key": private_key,
+        }
+        self._prepare_domains_data(data, domains)
+        
+        if csr:
+            data["csr"] = csr
+        if trusted_certificates:
+            data["trusted_certificates"] = trusted_certificates
+        if client_certificate:
+            data["client_certificate"] = client_certificate
+
+        return self._post(endpoint, data=data)
+
+    def stage_and_activate(
+        self,
+        certificate: str,
+        private_key: str,
+        site_id: Optional[int] = None,
+        domain: Optional[str] = None,
+        domains: Optional[List[str]] = None,
+        csr: Optional[str] = None,
+        trusted_certificates: Optional[str] = None,
+        client_certificate: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Convenience method to stage and immediately activate a certificate.
+
+        Args matches stage().
+        
+        This method includes rollback logic: if activation fails, it attempts to
+        delete the staged certificate to prevent orphans.
+        """
+        # Stage the certificate first
+        stage_result = self.stage(
+            certificate=certificate,
+            private_key=private_key,
+            site_id=site_id,
+            domain=domain,
+            domains=domains,
+            csr=csr,
+            trusted_certificates=trusted_certificates,
+            client_certificate=client_certificate,
+        )
+
+        certificate_id = stage_result.get("ssl_custom_certificate_id")
+        if not certificate_id:
+            raise RuntimeError("Failed to get certificate ID from staging response")
+
+        try:
+            # Activate the staged certificate
+            activate_result = self.activate(
+                certificate_id=certificate_id,
+                site_id=site_id,
+                domain=domain,
+                domains=domains,
+            )
+
+            # Include the certificate ID in the response for convenience
+            activate_result["certificate_id"] = certificate_id
+            return activate_result
+            
+        except Exception as e:
+            # Rollback: Attempt to delete the staged certificate
+            try:
+                self.delete(certificate_id=certificate_id, site_id=site_id, domain=domain)
+            except Exception:
+                # Fallback: if delete fails, we can't do much more, but we swallow the delete error
+                # so the user sees the original activation error.
+                pass
+            raise e

--- a/atomic_sdk/client.py
+++ b/atomic_sdk/client.py
@@ -9,6 +9,7 @@ else:
 
 from .api.backups import BackupsClient
 from .api.client import ClientClient
+from .api.custom_certificates import CustomCertificatesClient
 from .api.edge_cache import EdgeCacheClient
 from .api.email import EmailClient
 from .api.metrics import MetricsClient
@@ -60,6 +61,7 @@ class AtomicClient:
         # Instantiate and attach all the resource-specific clients
         self.backups = BackupsClient(self._session, self.BASE_URL, self.client_id_or_name)
         self.client = ClientClient(self._session, self.BASE_URL, self.client_id_or_name)
+        self.custom_certificates = CustomCertificatesClient(self._session, self.BASE_URL, self.client_id_or_name)
         self.edge_cache = EdgeCacheClient(self._session, self.BASE_URL, self.client_id_or_name)
         self.email = EmailClient(self._session, self.BASE_URL, self.client_id_or_name)
         self.metrics = MetricsClient(self._session, self.BASE_URL, self.client_id_or_name)

--- a/examples/README.md
+++ b/examples/README.md
@@ -102,6 +102,17 @@ Once your site exists, you can perform various management tasks.
     *   Retrying a failed SSL provisioning attempt with `client.sites.retry_ssl_provisioning()`.
     *   Managing HSTS settings like `includeSubDomains` with `client.sites.set_hsts_subdomain()`.
 
+### 🔐 Manage Custom SSL Certificates
+*   **Run:** `python examples/custom_certificates/01_install_certificate.py --cert <file> --key <file>`
+*   **Shows:**
+    *   Validating a certificate pair with `client.custom_certificates.validate()`.
+    *   Staging and activating in one step with `client.custom_certificates.stage_and_activate()`.
+*   **Run:** `python examples/custom_certificates/02_manage_certificate.py list`
+*   **Shows:**
+    *   Listing all certificates for a site.
+    *   Getting the currently active certificate with `active` subcommand.
+    *   Subcommands for `deactivate` and `delete` to manage specific certificate IDs.
+
 ### 🗃️ Access the Database
 *   **Run:** `python examples/sites/06_get_phpmyadmin_url.py`
 *   **Shows:**

--- a/examples/custom_certificates/01_install_certificate.py
+++ b/examples/custom_certificates/01_install_certificate.py
@@ -1,0 +1,110 @@
+"""
+Example: Install Custom SSL Certificate
+
+This script validates, stages, and activates a custom SSL certificate for a site.
+It accepts certificate and private key files as command-line arguments.
+
+Usage:
+    python 01_install_certificate.py --cert /path/to/cert.pem --key /path/to/key.pem [--domain example.com]
+"""
+
+import os
+import argparse
+import sys
+from dotenv import load_dotenv
+from atomic_sdk import AtomicClient, AtomicAPIError, NotFoundError
+
+# Load environment variables
+load_dotenv()
+API_KEY = os.environ.get("ATOMIC_API_KEY")
+CLIENT_ID = os.environ.get("ATOMIC_CLIENT_ID")
+DEFAULT_DOMAIN = os.environ.get("SITE_DOMAIN")
+
+
+def read_file(path):
+    """Reads content from a file."""
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        print(f"Error: File not found: {path}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading file {path}: {e}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install a custom SSL certificate on WP Cloud.")
+    parser.add_argument("--cert", required=True, help="Path to the PEM-encoded certificate file")
+    parser.add_argument("--key", required=True, help="Path to the PEM-encoded private key file")
+    parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain (defaults to SITE_DOMAIN env var)")
+    parser.add_argument("--validate-only", action="store_true", help="Only validate, do not install")
+
+    args = parser.parse_args()
+
+    if not API_KEY or not CLIENT_ID:
+        print("Error: ATOMIC_API_KEY and ATOMIC_CLIENT_ID must be set in your .env file.")
+        return
+
+    if not args.domain:
+        print("Error: Domain must be provided via --domain or SITE_DOMAIN env var.")
+        return
+
+    print("--- Initializing AtomicClient ---")
+    client = AtomicClient(api_key=API_KEY, client_id_or_name=CLIENT_ID)
+
+    # Read files
+    cert_content = read_file(args.cert)
+    key_content = read_file(args.key)
+    print(f"Read certificate ({len(cert_content)} bytes) and key ({len(key_content)} bytes).")
+
+    try:
+        # 1. Validate
+        print(f"\n--- Validating Certificate for '{args.domain}' ---")
+        validation = client.custom_certificates.validate(
+            certificate=cert_content,
+            private_key=key_content,
+            domain=args.domain
+        )
+        
+        is_valid = validation.get('valid')
+        if not is_valid:
+            print("❌ Validation Failed!")
+            if 'errors' in validation:
+                print("Errors:")
+                for err in validation['errors']:
+                    print(f"  - {err}")
+            return
+        
+        print("✅ Certificate is valid.")
+        if args.validate_only:
+            print("Validate-only mode enabled. Exiting.")
+            return
+
+        # 2. Stage and Activate
+        print(f"\n--- Staging and Activating Certificate ---")
+        result = client.custom_certificates.stage_and_activate(
+            certificate=cert_content,
+            private_key=key_content,
+            domain=args.domain
+        )
+        
+        cert_id = result.get('certificate_id')
+        activated = result.get('activated')
+        
+        if activated:
+            print(f"✅ Success! Certificate {cert_id} has been activated for: {result.get('domains')}")
+        else:
+            print(f"⚠️ Certificate staged (ID: {cert_id}) but activation status is false.")
+
+    except NotFoundError:
+        print(f"Error: Site '{args.domain}' not found.")
+    except AtomicAPIError as e:
+        print(f"API Error: {e}")
+    except Exception as e:
+        print(f"Unexpected Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/custom_certificates/01_install_certificate.py
+++ b/examples/custom_certificates/01_install_certificate.py
@@ -91,12 +91,7 @@ def main():
         )
         
         cert_id = result.get('certificate_id')
-        activated = result.get('activated')
-        
-        if activated:
-            print(f"✅ Success! Certificate {cert_id} has been activated for: {result.get('domains')}")
-        else:
-            print(f"⚠️ Certificate staged (ID: {cert_id}) but activation status is false.")
+        print(f"✅ Success! Certificate {cert_id} has been activated for: {result.get('domains')}")
 
     except NotFoundError:
         print(f"Error: Site '{args.domain}' not found.")

--- a/examples/custom_certificates/02_manage_certificate.py
+++ b/examples/custom_certificates/02_manage_certificate.py
@@ -1,0 +1,101 @@
+"""
+Example: Manage Custom SSL Certificates
+
+This script allows you to list, deactivate, and delete custom SSL certificates.
+
+Usage:
+    python 02_manage_certificate.py [list|deactivate|delete] [--domain example.com] [--id CERT_ID]
+"""
+
+import os
+import argparse
+import sys
+from dotenv import load_dotenv
+from atomic_sdk import AtomicClient, AtomicAPIError, NotFoundError
+
+load_dotenv()
+API_KEY = os.environ.get("ATOMIC_API_KEY")
+CLIENT_ID = os.environ.get("ATOMIC_CLIENT_ID")
+DEFAULT_DOMAIN = os.environ.get("SITE_DOMAIN")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage custom SSL certificates on WP Cloud.")
+    subparsers = parser.add_subparsers(dest='command', help='Command to execute', required=True)
+
+    # List command
+    list_parser = subparsers.add_parser('list', help='List certificates')
+    list_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain")
+    list_parser.add_argument("--status", choices=['active', 'staged', 'all'], help="Filter by status")
+
+    # Active command
+    active_parser = subparsers.add_parser('active', help='Get active certificate')
+    active_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain")
+
+    # Deactivate command
+    deactivate_parser = subparsers.add_parser('deactivate', help='Deactivate a certificate')
+    deactivate_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain")
+    deactivate_parser.add_argument("--id", type=int, required=True, help="Certificate ID to deactivate")
+
+    # Delete command
+    delete_parser = subparsers.add_parser('delete', help='Delete a certificate')
+    delete_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain")
+    delete_parser.add_argument("--id", type=int, required=True, help="Certificate ID to delete")
+
+    args = parser.parse_args()
+
+    if not API_KEY or not CLIENT_ID:
+        print("Error: ATOMIC_API_KEY and ATOMIC_CLIENT_ID must be set in your .env file.")
+        return
+
+    domain = args.domain
+    if not domain:
+        print("Error: Domain must be provided via --domain or SITE_DOMAIN env var.")
+        return
+
+    client = AtomicClient(api_key=API_KEY, client_id_or_name=CLIENT_ID)
+
+    try:
+        if args.command == 'list':
+            print(f"--- Listing certificates for '{domain}' ---")
+            result = client.custom_certificates.list(domain=domain, status=args.status)
+            certs = result.get('certificates', [])
+            
+            if not certs:
+                print("No certificates found.")
+            
+            for cert in certs:
+                status_icon = "🟢" if cert.get('is_active') else "⚪"
+                print(f"{status_icon} ID: {cert.get('ssl_custom_certificate_id')} | "
+                      f"Issued To: {cert.get('issued_to')} | "
+                      f"Expires: {cert.get('expires_at')}")
+
+        elif args.command == 'active':
+            print(f"--- Getting active certificate for '{domain}' ---")
+            cert = client.custom_certificates.get_active(domain=domain)
+            if cert:
+                print(f"🟢 Active Certificate ID: {cert.get('ssl_custom_certificate_id')}")
+                print(f"Issued To: {cert.get('issued_to')}")
+            else:
+                print("⚪ No active certificate found.")
+
+        elif args.command == 'deactivate':
+            print(f"--- Deactivating certificate ID {args.id} on '{domain}' ---")
+            client.custom_certificates.deactivate(certificate_id=args.id, domain=domain)
+            print("✅ Certificate deactivated.")
+
+        elif args.command == 'delete':
+            print(f"--- Deleting certificate ID {args.id} on '{domain}' ---")
+            client.custom_certificates.delete(certificate_id=args.id, domain=domain)
+            print("✅ Certificate deleted.")
+
+    except NotFoundError:
+        print(f"Error: Site '{domain}' or certificate ID not found.")
+    except AtomicAPIError as e:
+        print(f"API Error: {e}")
+    except Exception as e:
+        print(f"Unexpected Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/custom_certificates/02_manage_certificate.py
+++ b/examples/custom_certificates/02_manage_certificate.py
@@ -75,14 +75,14 @@ def main():
             cert = client.custom_certificates.get_active(domain=domain)
             if cert:
                 cert_id = cert.get('ssl_custom_certificate_id')
-                if getattr(args, 'id_only', False):
+                if args.id_only:
                     print(cert_id)
                 else:
                     print(f"--- Getting active certificate for '{domain}' ---")
                     print(f"🟢 Active Certificate ID: {cert_id}")
                     print(f"Issued To: {cert.get('issued_to')}")
             else:
-                if not getattr(args, 'id_only', False):
+                if not args.id_only:
                     print(f"--- Getting active certificate for '{domain}' ---")
                     print("⚪ No active certificate found.")
 

--- a/examples/custom_certificates/02_manage_certificate.py
+++ b/examples/custom_certificates/02_manage_certificate.py
@@ -1,15 +1,15 @@
 """
 Example: Manage Custom SSL Certificates
 
-This script allows you to list, deactivate, and delete custom SSL certificates.
+This script allows you to list certificates, get the active certificate, deactivate certificates, and delete custom SSL certificates.
 
 Usage:
-    python 02_manage_certificate.py [list|deactivate|delete] [--domain example.com] [--id CERT_ID]
+    python 02_manage_certificate.py [list|active|deactivate|delete] [--domain example.com] [--status {active,staged,all}] [--id CERT_ID] [--id-only]
 """
 
 import os
 import argparse
-import sys
+
 from dotenv import load_dotenv
 from atomic_sdk import AtomicClient, AtomicAPIError, NotFoundError
 

--- a/examples/custom_certificates/02_manage_certificate.py
+++ b/examples/custom_certificates/02_manage_certificate.py
@@ -31,6 +31,7 @@ def main():
     # Active command
     active_parser = subparsers.add_parser('active', help='Get active certificate')
     active_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Target domain")
+    active_parser.add_argument("--id-only", action="store_true", help="Only output the certificate ID (for scripting)")
 
     # Deactivate command
     deactivate_parser = subparsers.add_parser('deactivate', help='Deactivate a certificate')
@@ -71,13 +72,19 @@ def main():
                       f"Expires: {cert.get('expires_at')}")
 
         elif args.command == 'active':
-            print(f"--- Getting active certificate for '{domain}' ---")
             cert = client.custom_certificates.get_active(domain=domain)
             if cert:
-                print(f"🟢 Active Certificate ID: {cert.get('ssl_custom_certificate_id')}")
-                print(f"Issued To: {cert.get('issued_to')}")
+                cert_id = cert.get('ssl_custom_certificate_id')
+                if getattr(args, 'id_only', False):
+                    print(cert_id)
+                else:
+                    print(f"--- Getting active certificate for '{domain}' ---")
+                    print(f"🟢 Active Certificate ID: {cert_id}")
+                    print(f"Issued To: {cert.get('issued_to')}")
             else:
-                print("⚪ No active certificate found.")
+                if not getattr(args, 'id_only', False):
+                    print(f"--- Getting active certificate for '{domain}' ---")
+                    print("⚪ No active certificate found.")
 
         elif args.command == 'deactivate':
             print(f"--- Deactivating certificate ID {args.id} on '{domain}' ---")


### PR DESCRIPTION
https://github.com/user-attachments/assets/fdf568c4-9d8b-430a-a794-b6c6445520de

### Summary
Add complete support for managing Custom SSL Certificates via the WP Cloud API, including a client library implementation and example scripts.

### Changes

| File | Description |
|------|-------------|
| `atomic_sdk/api/custom_certificates.py` | New API client with full certificate lifecycle support |
| `atomic_sdk/client.py` | Register `custom_certificates` client |
| `examples/custom_certificates/01_install_certificate.py` | Example: Validate, stage & activate a certificate |
| `examples/custom_certificates/02_manage_certificate.py` | Example: List, get active, deactivate & delete certificates |
| `examples/README.md` | Documentation for new examples |
| `README.md` | Add Custom SSL Certificates section |

### API Methods

| Method | Description |
|--------|-------------|
| `validate()` | Validate certificate/key pair without saving |
| `stage()` | Upload certificate to staging |
| `activate()` | Activate a staged certificate |
| `deactivate()` | Deactivate an active certificate |
| `delete()` | Remove a certificate |
| `get()` | Get certificate details by ID |
| `list()` | List all certificates for a site |
| `update()` | Renew/update existing certificate |
| `stage_and_activate()` | Convenience method with rollback on failure |
| `get_active()` | Helper to retrieve currently active certificate |

### Usage Examples

```bash
# Install a certificate
python examples/custom_certificates/01_install_certificate.py \
  --cert /path/to/cert.crt --key /path/to/key.key --domain example.com

# Manage certificates
python examples/custom_certificates/02_manage_certificate.py list --domain example.com
python examples/custom_certificates/02_manage_certificate.py active --domain example.com
python examples/custom_certificates/02_manage_certificate.py active --domain example.com --id-only
python examples/custom_certificates/02_manage_certificate.py deactivate --id 123 --domain example.com
python examples/custom_certificates/02_manage_certificate.py delete --id 123 --domain example.com
```

### Testing
Tested against live WP Cloud environment with custom SSL certificates. Demo recording attached.
