### PR TITLE
Wire up _client reference for Job.status() to poll disconnect jobs

### DIFF
--- a/atomic_sdk/client.py
+++ b/atomic_sdk/client.py
@@ -71,8 +71,10 @@ class AtomicClient:
         self.tasks = TasksClient(self._session, self.BASE_URL, self.client_id_or_name)
         self.utility = UtilityClient(self._session, self.BASE_URL, self.client_id_or_name)
 
-        # Pass a reference of the main client to the sites client for job status checks
+        # Pass a reference of the main client to resource clients that return Job objects,
+        # so Job.status() can call self._client.sites.get_job_status().
         self.sites._client = self
+        self.ssh._client = self
 
     def __repr__(self):
         return f"<AtomicClient client_id='{self.client_id_or_name}'>"


### PR DESCRIPTION
Fix `Job.status()` failure for SSH disconnect jobs

`SSHClient.disconnect_all_users()` returns a `Job` and assigns `job._client = self._client` so the job can later fetch status. However, `AtomicClient.__init__` only initialized the client reference for `sites`, leaving `ssh._client` unset.

As a result, SSH disconnect jobs were created with a `None` client reference, causing `Job.status()` to raise:

`RuntimeError: Job object must be initialized with a client reference to fetch status.`

This change wires `self.ssh._client = self` during `AtomicClient` initialization, matching the existing `sites` setup and allowing SSH disconnect jobs to fetch their status correctly.